### PR TITLE
Events Archive

### DIFF
--- a/wp-content/themes/csisnuclearnetwork/archive-events.php
+++ b/wp-content/themes/csisnuclearnetwork/archive-events.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * The Archive template.
+ *
+ * @package CSIS iLab
+ * @subpackage @package NuclearNetwork
+ * @since 1.0.0
+ */
+
+$term = get_queried_object();
+
+get_header();
+?>
+
+<main id="site-content" role="main">
+
+	<?php
+		get_template_part( 'template-parts/entry-header' );
+	?>
+
+	<div class='archive__content'>
+
+	<?php
+		if ( have_posts() ) {
+			echo '<h2 class="archive__section-title">Past Events</h2>';
+			nuclearnetwork_pagination_number_of_posts();
+
+			echo '<section class="archive__base">';
+			while ( have_posts() ) {
+				the_post();
+				get_template_part( 'template-parts/block-post', get_post_type() );
+			}
+			echo "</section>";
+			wp_reset_postdata();
+
+		  get_template_part( 'template-parts/pagination' );
+
+    }
+
+	?>
+	</div>
+
+</main><!-- #site-content -->
+
+<?php
+get_footer();

--- a/wp-content/themes/csisnuclearnetwork/archive-events.php
+++ b/wp-content/themes/csisnuclearnetwork/archive-events.php
@@ -23,7 +23,7 @@ get_header();
 			if ( have_posts() && !is_paged() ) {
 		?>
 		<h2 class="archive__section-title">Upcoming Events</h2>
-		<section class="events__upcoming">
+		<section class="archive__postlist events__upcoming">
 		<?php
 			$upcoming_args = array(
 				'post_type' => 'events',
@@ -60,16 +60,16 @@ get_header();
 			echo '<h2 class="archive__section-title">Past Events</h2>';
 			nuclearnetwork_pagination_number_of_posts( array("parent_tag" => "div") );
 
-			echo '<section class="archive__base">';
+			echo '<section class="archive__postlist">';
 			while ( have_posts() ) {
 				the_post();
 				get_template_part( 'template-parts/block-post', get_post_type() );
 			}
-			echo "</section>";
 			wp_reset_postdata();
 
 		  get_template_part( 'template-parts/pagination' );
 
+			echo "</section>";
     }
 
 	?>

--- a/wp-content/themes/csisnuclearnetwork/archive-events.php
+++ b/wp-content/themes/csisnuclearnetwork/archive-events.php
@@ -19,6 +19,9 @@ get_header();
 	?>
 
 	<div class='archive__content'>
+		<?php
+			if ( have_posts() && !is_paged() ) {
+		?>
 		<h2 class="archive__section-title">Upcoming Events</h2>
 		<section class="events__upcoming">
 		<?php
@@ -51,7 +54,7 @@ get_header();
 			}
 		?>
 		</section>
-
+	<?php } ?>
 	<?php
 		if ( have_posts() ) {
 			echo '<h2 class="archive__section-title">Past Events</h2>';

--- a/wp-content/themes/csisnuclearnetwork/archive-events.php
+++ b/wp-content/themes/csisnuclearnetwork/archive-events.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The Archive template.
+ * The Archive template for the Events post type.
  *
  * @package CSIS iLab
  * @subpackage @package NuclearNetwork

--- a/wp-content/themes/csisnuclearnetwork/archive-events.php
+++ b/wp-content/themes/csisnuclearnetwork/archive-events.php
@@ -8,22 +8,54 @@
  */
 
 $term = get_queried_object();
+$date_now = date('Y-m-d H:i:s');
 
 get_header();
 ?>
 
 <main id="site-content" role="main">
-
 	<?php
 		get_template_part( 'template-parts/entry-header' );
 	?>
 
 	<div class='archive__content'>
+		<h2 class="archive__section-title">Upcoming Events</h2>
+		<section class="events__upcoming">
+		<?php
+			$upcoming_args = array(
+				'post_type' => 'events',
+				'post_status' => 'publish',
+				'meta_query' => array(
+					'relation' => 'OR',
+        	array(
+            'key'           => 'event_post_info_event_start_date',
+            'compare'       => '>=',
+            'value'         => $date_now,
+            'type'          => 'DATE',
+					),
+    		),
+				'orderby' => 'meta_value',
+				'order' => 'ASC'
+			);
+
+			$upcoming_posts = new WP_Query( $upcoming_args );
+
+			if ( $upcoming_posts->have_posts() ) {
+				while ( $upcoming_posts->have_posts() ) {
+					$upcoming_posts->the_post();
+					get_template_part( 'template-parts/block-post', get_post_type() );
+				}
+				wp_reset_postdata();
+			} else {
+				echo '<p class="archive__disclaimer text--long">There are no upcoming events at the moment. Check back soon!</p>';
+			}
+		?>
+		</section>
 
 	<?php
 		if ( have_posts() ) {
 			echo '<h2 class="archive__section-title">Past Events</h2>';
-			nuclearnetwork_pagination_number_of_posts();
+			nuclearnetwork_pagination_number_of_posts( array("parent_tag" => "div") );
 
 			echo '<section class="archive__base">';
 			while ( have_posts() ) {

--- a/wp-content/themes/csisnuclearnetwork/archive.php
+++ b/wp-content/themes/csisnuclearnetwork/archive.php
@@ -43,15 +43,15 @@ get_header();
 		}
 
 		if ( have_posts() ) {
-			echo '<section class="archive__base">';
+			echo '<section class="archive__postlist">';
 			while ( have_posts() ) {
 				the_post();
 				get_template_part( 'template-parts/block-post', get_post_type() );
 			}
-			echo "</section>";
 			wp_reset_postdata();
+			get_template_part( 'template-parts/pagination' );
+			echo "</section>";
 		}
-		get_template_part( 'template-parts/pagination' );
 
 		if (class_exists('ACF') && !is_paged()) {
 			$cards = get_field('card', $term);

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/abstracts/_variables.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/abstracts/_variables.scss
@@ -176,3 +176,11 @@ $page-images: (
     ),
   ),
 );
+
+/*----------  Archive Content Widths  ----------*/
+$archive-widths: (
+  'post-type-archive-events': (
+    'content': 930px,
+    'postlist': 800px,
+  ),
+);

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_pagination.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_pagination.scss
@@ -7,6 +7,12 @@
   @extend %text-style-label-medium;
   font-weight: normal;
   border-bottom: 1px solid $color-border-dark-130;
+
+  .archive__section-title + & {
+    margin-top: rem(-8); // Offset title's margin bottom
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
 }
 
 .pagination__wrapper {

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/archive.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/archive.scss
@@ -66,7 +66,6 @@
   }
 
   &__disclaimer {
-    margin-bottom: rem(56);
     color: $color-black-180;
     @extend %text-style-paragraph-large;
   }

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/archive.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/archive.scss
@@ -18,6 +18,14 @@
     }
   }
 
+  &__section-title {
+    margin-bottom: rem(16);
+    padding-bottom: rem(8);
+    color: $color-black-165;
+    @extend %text-style-heading-x-large;
+    border-bottom: 1px solid $color-border-dark-130;
+  }
+
   &__featured {
     .post-block {
       padding-top: rem(34);
@@ -41,6 +49,12 @@
         }
       }
     }
+  }
+
+  &__disclaimer {
+    margin-bottom: rem(56);
+    color: $color-black-180;
+    @extend %text-style-paragraph-large;
   }
 }
 
@@ -92,5 +106,22 @@
     @extend %text-style-label-large;
     display: flex;
     color: $color-white-190;
+  }
+}
+
+/*----------  Events  ----------*/
+.events__upcoming {
+  padding-top: rem(16);
+
+  @include breakpoint('medium') {
+    padding-top: rem(24);
+  }
+
+  > :last-child {
+    margin-bottom: rem(40);
+
+    @include breakpoint('large') {
+      margin-bottom: rem(48);
+    }
   }
 }

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/archive.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/archive.scss
@@ -1,11 +1,19 @@
 @use '../abstracts' as *;
+@use 'sass:map';
 @use '../components/pagination';
+
+@each $page, $values in $archive-widths {
+  .#{$page} {
+    --content-width: #{map.get($values, 'content')};
+    --postlist-width: #{map.get($values, 'postlist')};
+  }
+}
 
 .archive {
   background: $color-bg-light-200;
 
   &__content {
-    max-width: $size__archive-max-width;
+    max-width: var(--content-width, #{$size__archive-max-width});
     margin-right: auto;
     margin-left: auto;
 
@@ -16,6 +24,12 @@
         margin-bottom: rem(56);
       }
     }
+  }
+
+  &__postlist {
+    max-width: var(--postlist-width, 100%);
+    margin-right: auto;
+    margin-left: auto;
   }
 
   &__section-title {

--- a/wp-content/themes/csisnuclearnetwork/inc/template-functions.php
+++ b/wp-content/themes/csisnuclearnetwork/inc/template-functions.php
@@ -313,25 +313,60 @@ if ( class_exists( 'easyFootnotes' ) ) {
  * @param  array $query Query object.
  */
 
-function nuclearnetwork_exclude_related__posts_from_archive( $query ) {
+// function nuclearnetwork_exclude_related__posts_from_archive( $query ) {
 
-	if ( $query->is_main_query() && ! is_admin() && is_archive() ) {
-        $term = get_queried_object();
-		$featured_post = get_field( 'featured_post', $term->name );
+// 	if ( $query->is_main_query() && ! is_admin() && is_archive() ) {
+//         $term = get_queried_object();
+// 		$featured_post = get_field( 'featured_post', $term->name );
 
-		if ( $featured_post ) {
-				$excluded_post_ids = array();
+// 		if ( $featured_post ) {
+// 				$excluded_post_ids = array();
 
-				foreach ($featured_post as $post) {
-					$excluded_post_ids[] = $post->ID;
-				}
+// 				foreach ($featured_post as $post) {
+// 					$excluded_post_ids[] = $post->ID;
+// 				}
 
-			$query->set( 'post__not_in', $excluded_post_ids);
-		}
+// 			$query->set( 'post__not_in', $excluded_post_ids);
+// 		}
 
+// 	}
+// }
+// add_action( 'pre_get_posts', 'nuclearnetwork_exclude_related__posts_from_archive' );
+
+// /**
+//  * Modify Events Archive loop to exclude Upcoming events and be sorted by start date.
+//  *
+//  * @param  array $query Query object.
+//  */
+
+function nuclearnetwork_exclude_upcoming_events_from_archive_loop ( $query ) {
+
+	if ( !is_admin() && $query->is_main_query() && is_post_type_archive( 'events' ) ) {
+		// $query->set('orderby', 'meta_value');
+
+		$query->set('meta_query', array(
+			'relation' => 'OR',
+			'_post_start_date' => array(
+				'key' => '_post_start_date',
+			),
+			'event_post_info_event_start_date' => array(
+				'key' => 'event_post_info_event_start_date',
+			)
+		));
+
+		$query->set('orderby', array(
+			'_post_start_date' => 'DESC',
+			'event_post_info_event_start_date' => 'DESC',
+		));
+
+		// echo '<pre>';
+		// var_dump($query);
+		// echo '</pre>';
 	}
+
+	// return $query;
 }
-add_action( 'pre_get_posts', 'nuclearnetwork_exclude_related__posts_from_archive' );
+add_action( 'pre_get_posts', 'nuclearnetwork_exclude_upcoming_events_from_archive_loop' );
 
 /*
  * Removes the default Jetpack related posts plugin so we can call it with a shortcode instead
@@ -366,7 +401,7 @@ function jetpackme_more_related_posts( $options ) {
 // function nuclearnetwork_remove_selected_categories( $categories ) {
 // 	$excluded_topics = get_field( 'excluded_topic', 'option' );
 // 	$excluded_topic_names = array();
-	
+
 // 	foreach ( $excluded_topics as $topic ) {
 // 		$excluded_topic_names[] = $topic->slug;
 // 	}

--- a/wp-content/themes/csisnuclearnetwork/inc/template-functions.php
+++ b/wp-content/themes/csisnuclearnetwork/inc/template-functions.php
@@ -342,8 +342,13 @@ if ( class_exists( 'easyFootnotes' ) ) {
 function nuclearnetwork_exclude_upcoming_events_from_archive_loop ( $query ) {
 
 	if ( !is_admin() && $query->is_main_query() && is_post_type_archive( 'events' ) ) {
-		// $query->set('orderby', 'meta_value');
 
+		$date_now = date('Y-m-d H:i:s');
+
+		/**
+		 * `_post_start_date` was a custom meta field from a previous theme. It's inclusion here is to ensure that older event posts are also sorted accordingly. Note that the two "date" fields are treated separately, so the chronological order of past events may be incorrect when the query starts using the older meta field instead of the ACF.
+		 * TODO: Convert old event posts to use new ACF start date field for consistent ordering.
+		 */
 		$query->set('meta_query', array(
 			'relation' => 'OR',
 			'_post_start_date' => array(
@@ -351,20 +356,17 @@ function nuclearnetwork_exclude_upcoming_events_from_archive_loop ( $query ) {
 			),
 			'event_post_info_event_start_date' => array(
 				'key' => 'event_post_info_event_start_date',
-			)
+				'compare'       => '<',
+				'value'         => $date_now,
+				'type'          => 'DATE',
+			),
 		));
 
 		$query->set('orderby', array(
 			'_post_start_date' => 'DESC',
 			'event_post_info_event_start_date' => 'DESC',
 		));
-
-		// echo '<pre>';
-		// var_dump($query);
-		// echo '</pre>';
 	}
-
-	// return $query;
 }
 add_action( 'pre_get_posts', 'nuclearnetwork_exclude_upcoming_events_from_archive_loop' );
 

--- a/wp-content/themes/csisnuclearnetwork/inc/template-functions.php
+++ b/wp-content/themes/csisnuclearnetwork/inc/template-functions.php
@@ -313,31 +313,31 @@ if ( class_exists( 'easyFootnotes' ) ) {
  * @param  array $query Query object.
  */
 
-// function nuclearnetwork_exclude_related__posts_from_archive( $query ) {
+function nuclearnetwork_exclude_related__posts_from_archive( $query ) {
 
-// 	if ( $query->is_main_query() && ! is_admin() && is_archive() ) {
-//         $term = get_queried_object();
-// 		$featured_post = get_field( 'featured_post', $term->name );
+	if ( $query->is_main_query() && ! is_admin() && is_archive() ) {
+    $term = get_queried_object();
+		$featured_post = get_field( 'featured_post', $term->name );
 
-// 		if ( $featured_post ) {
-// 				$excluded_post_ids = array();
+		if ( $featured_post ) {
+			$excluded_post_ids = array();
 
-// 				foreach ($featured_post as $post) {
-// 					$excluded_post_ids[] = $post->ID;
-// 				}
+			foreach ($featured_post as $post) {
+				$excluded_post_ids[] = $post->ID;
+			}
 
-// 			$query->set( 'post__not_in', $excluded_post_ids);
-// 		}
+			$query->set( 'post__not_in', $excluded_post_ids);
+		}
 
-// 	}
-// }
-// add_action( 'pre_get_posts', 'nuclearnetwork_exclude_related__posts_from_archive' );
+	}
+}
+add_action( 'pre_get_posts', 'nuclearnetwork_exclude_related__posts_from_archive' );
 
-// /**
-//  * Modify Events Archive loop to exclude Upcoming events and be sorted by start date.
-//  *
-//  * @param  array $query Query object.
-//  */
+/**
+ * Modify Events Archive loop to exclude Upcoming events and be sorted by start date.
+ *
+ * @param  array $query Query object.
+ */
 
 function nuclearnetwork_exclude_upcoming_events_from_archive_loop ( $query ) {
 

--- a/wp-content/themes/csisnuclearnetwork/inc/template-tags.php
+++ b/wp-content/themes/csisnuclearnetwork/inc/template-tags.php
@@ -373,7 +373,7 @@ endif;
  * @return string $html The share links.
  */
 if (! function_exists('nuclearnetwork_pagination_number_of_posts')) :
-	function nuclearnetwork_pagination_number_of_posts() {
+	function nuclearnetwork_pagination_number_of_posts( $args = array("parent_tag" => "h2") ) {
 		global $wp_query;
 		$total_posts = $wp_query->found_posts;
 		$page = (get_query_var('paged')) ? get_query_var('paged') : 1;
@@ -381,7 +381,7 @@ if (! function_exists('nuclearnetwork_pagination_number_of_posts')) :
 
 		if ( $total_posts > 0 ) {
 			/* translators: 1: list of tags. */
-			printf( '<h2 class="pagination__results">' . esc_html__( '%1$s', 'nuclearnetwork' ) . ' Items, Page ' . esc_html__( '%2$s', 'nuclearnetwork' ) . ' of ' . esc_html__( '%3$s', 'nuclearnetwork' ) . '</h2>', $total_posts, $page, $pages ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			printf( '<' . esc_html__( '%1$s', 'nuclearnetwork' ) . ' class="pagination__results">' . esc_html__( '%2$s', 'nuclearnetwork' ) . ' Items, Page ' . esc_html__( '%3$s', 'nuclearnetwork' ) . ' of ' . esc_html__( '%4$s', 'nuclearnetwork' ) . '</' . esc_html__( '%1$s', 'nuclearnetwork' ) . '>', $args['parent_tag'], $total_posts, $page, $pages ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 endif;
@@ -413,11 +413,11 @@ endif;
 if (! function_exists('nuclearnetwork_display_subtypes')) :
 	function nuclearnetwork_display_subtypes() {
 
-		
+
 		// $post_type = get_post_type();
 		$post_type = get_post_type_object(get_post_type());
 		global $post;
-		
+
 		if ( in_array( $post_type->name, array( 'events', 'updates' ) ) || ( $post_type->name === 'programs' && is_single() ) ) {
 			$post_type_name = $post_type->labels->singular_name;
 			$tax_name = $post_type->taxonomies[0];
@@ -425,7 +425,7 @@ if (! function_exists('nuclearnetwork_display_subtypes')) :
 			$post_type_name = get_the_title( get_option( 'page_for_posts' ) );
 			$tax_name = 'analysis_subtype';
 		}
-		
+
 		echo '<div class="post-meta post-meta__terms"><a href="' . get_post_type_archive_link( $post_type ) . '" class="post-meta__terms-type text--bold">' . $post_type_name . get_the_term_list( $post->ID, $tax_name, ' /&nbsp</a>', ',&nbsp') . '</div>';
 	}
 endif;
@@ -440,7 +440,7 @@ if (! function_exists('nuclearnetwork_display_series')) :
 	function nuclearnetwork_display_series() {
 
 		global $post;
-		
+
 		echo get_the_term_list( $post->ID, 'series', '<dl class="post-meta post-meta__series text--italic"><dt class="post-meta__label">Series </dt><dd>', ', ', '</dd></dl>');
 	}
 endif;

--- a/wp-content/themes/csisnuclearnetwork/index.php
+++ b/wp-content/themes/csisnuclearnetwork/index.php
@@ -36,7 +36,7 @@ get_header();
 			// vars
 			$featured_post = get_field('featured_post', $term->name);
 			if ( $featured_post ) {
-				
+
 				echo '<section class="archive__featured">';
 				foreach( $featured_post as $post ):
 					// Setup this post for WP functions (variable must be named $post).
@@ -51,7 +51,7 @@ get_header();
 		}
 
 		if ( have_posts() ) {
-			echo '<section class="archive__base">';
+			echo '<section class="archive__postlist">';
 			while ( have_posts() ) {
 				the_post();
 				get_template_part( 'template-parts/block-post', get_post_type() );

--- a/wp-content/themes/csisnuclearnetwork/search.php
+++ b/wp-content/themes/csisnuclearnetwork/search.php
@@ -27,7 +27,7 @@ get_header();
 
 			nuclearnetwork_pagination_number_of_posts();
 
-			echo '<section class="archive__base">';
+			echo '<section class="archive__postlist">';
 			while ( have_posts() ) {
 				the_post();
 
@@ -41,7 +41,7 @@ get_header();
 			?>
 
 			<div class="no-search-results-form section-inner thin">
-		
+
 			<h2 class="search-form__title"><?php esc_html_e( 'No Results', 'nuclearnetwork' ); ?></h2>
 
 			<p class="search-form__desc"><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with different keywords.', 'nuclearnetwork' ); ?></p>
@@ -54,7 +54,7 @@ get_header();
 				);
 
 				?>
-				
+
 			</div><!-- .no-search-results -->
 
 			<?php


### PR DESCRIPTION
Makes progress on #93 

## Overview

- Creates template file for Events archive
- Makes modifications to the default archive template
- Establishes a reusable `.archive__section-title` class that can be used on other archive pages
- Adds an argument that can be passed to the pagination results function that changes the default parent HTML tag from an `<h2>` to the given argument (such as a `<h3>` or `<div>`) to maintain semantics with the headings
- Sets up a reusable Sass map in `_variables.scss` to control the max width of the `content` and `postlist` sections of the archive. Note that the "key" of the map should be unique classes for each of the archive pages, such as `.post-type-archive-[post type name]`. I defined `content` as the size of the main content/container area of the archive, and `postlist` as the list of posts. If `content` is undefined, it will default to the value of `$size__archive-max-width`, and if `postlist` is undefined, it will default to 100% or the size of the `content` area. 
  - I modified the default archive & search templates to use this same naming standard so it was consistent throughout. 

## Changes to Database
You'll probably want to pull down the DB to test this PR, or you can make these changes quickly on your local machine.
- I removed the "featured posts" ACF from the events archive
- I removed the S&F form for the Events Archive
- I updated the start date for the 2 upcoming PONI conferences

## What this PR doesn't do
You'll notice that there are some posts that are out of chronological order on the first page. This is because the posts that were created on the older NN theme used the `_post_start_date` field to store their event date information and the new posts use the ACF's `event_post_info_event_start_date`. Unfortunately I wasn't able to figure out a way to sort by both of these fields. Instead, the query sorts by one variable first, and then the second, resulting in the weird order that you see here. 

After fiddling with it, I think the easiest thing for us to do would be to delete the 2 future events (the fall & winter 2021 PONI conferences) and recreate them with the new format entirely. That should clear out any of the old metadata associated with them and make sure they're in the correct section. The rest of the posts seem mostly sorted in the right order, so I'm less concerned with those.

