### PR TITLE
Add series landing page

### DIFF
--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_post-block.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_post-block.scss
@@ -128,7 +128,8 @@
 
     .post-block.projects &,
     .post-block.programs &,
-    .post-block.news & {
+    .post-block.news &,
+    .post-block.series & {
       @extend %text-style-heading-large-strong;
       color: $color-accent-primary-blue-200;
 
@@ -162,7 +163,8 @@
     }
 
     .post-block.projects &,
-    .post-block.programs & {
+    .post-block.programs &,
+    .post-block.series & {
       &::after {
         content: '';
         display: block;

--- a/wp-content/themes/csisnuclearnetwork/functions.php
+++ b/wp-content/themes/csisnuclearnetwork/functions.php
@@ -182,7 +182,10 @@ function nuclearnetwork_register_styles() {
 		wp_enqueue_style( 'nuclearnetwork-style-home', get_stylesheet_directory_uri() . '/assets/css/pages/home.min.css', array(), $theme_version );
 	}
 
-	if ( is_archive() || is_search() || is_home() ) {
+	// Series Page as Archive
+	$series_page = get_field('series_page', 'option');
+
+	if ( is_archive() || is_search() || is_home() || is_page( $series_page->ID ) ) {
 		wp_enqueue_style( 'nuclearnetwork-style-archive', get_stylesheet_directory_uri() . '/assets/css/pages/archive.min.css', array(), $theme_version );
 	}
 
@@ -240,7 +243,10 @@ function nuclearnetwork_register_scripts() {
 		wp_script_add_data( 'nuclearnetwork-js-carousel', 'async', true );
 	}
 
-	if ( is_home() || is_archive() || is_search() ) {
+	// Series Page as Archive
+	$series_page = get_field('series_page', 'option');
+
+	if ( is_home() || is_archive() || is_search() || is_page( $series_page->ID ) ) {
 		wp_enqueue_script( 'nuclearnetwork-js-archive', get_template_directory_uri() . '/assets/js/archive.min.js', array(), $theme_version, true );
 		wp_script_add_data( 'nuclearnetwork-js-archive', 'defer', true );
 	}

--- a/wp-content/themes/csisnuclearnetwork/inc/template-functions.php
+++ b/wp-content/themes/csisnuclearnetwork/inc/template-functions.php
@@ -36,8 +36,11 @@ function nuclearnetwork_body_classes( $classes ) {
 	global $post;
 	$post_type = isset( $post ) ? $post->post_type : false;
 
+	// Series Page as Archive
+	$series_page = get_field('series_page', 'option');
+
 	// Check if we're the "blog page" or search page, and make them look like the archives.
-	if ( is_home() || is_search() ) {
+	if ( is_home() || is_search() || is_page( $series_page->ID ) ) {
 		$classes[] = 'archive';
 	}
 
@@ -73,6 +76,11 @@ function nuclearnetwork_body_classes( $classes ) {
 	// Does this archive page have filters?
 	if ( is_home() || 'post' === get_post_type() || is_author() || is_search() ) {
 		$classes[] = 'archive--has-filters';
+	}
+
+	// Check if post & add slug.
+	if ( $post_type ) {
+		$classes[] = $post->post_type . '-' . $post->post_name;
 	}
 
 	return $classes;

--- a/wp-content/themes/csisnuclearnetwork/page-series.php
+++ b/wp-content/themes/csisnuclearnetwork/page-series.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Template for displaying "Series" page
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package CSIS iLab
+ * @subpackage @package NuclearNetwork
+ * @since 1.0.0
+ */
+
+get_header(); ?>
+
+<main id="site-content" role="main">
+
+  <?php
+		get_template_part( 'template-parts/entry-header-blue' );
+	?>
+
+  <div class="archive__content">
+    <?php
+      $seriesList = get_terms( array(
+				'taxonomy' => 'series',
+				'hide_empty' => true,
+      ) );
+
+      if ( !empty($seriesList) ) {
+        foreach($seriesList as $post) : setup_postdata($post);
+          get_template_part( 'template-parts/block-series' );
+        endforeach;
+        wp_reset_postdata();
+      }
+    ?>
+
+  </div>
+</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/csisnuclearnetwork/template-parts/block-series.php
+++ b/wp-content/themes/csisnuclearnetwork/template-parts/block-series.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * The default template for displaying content
+ *
+ * Used for both singular and index.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package CSIS iLab
+ * @subpackage @package NuclearNetwork
+ * @since 1.0.0
+ */
+
+$classes = 'post-block series';
+$seriesURL = get_term_link( $post->term_id );
+$feature_img = get_field( 'featured_image', $post );
+
+?>
+<article <?php post_class( $classes ); ?> id="post-<?php echo $post->term_id; ?>">
+	<?php if ( $feature_img ) : ?>
+		<a href="<?php esc_url( $seriesURL ); ?>" class="post-block__img">
+			<img src="<?php echo esc_url($feature_img['url']); ?>" alt="<?php echo esc_attr($feature_img['alt']); ?>" />
+		</a>
+	<?php endif;
+
+	echo '<h2 class="post-block__title text--bold"><a href="' . esc_url( $seriesURL ) . '">' . $post->name . '</a></h2>';
+	echo '<p class="post-block__excerpt">' . $post->description . '</p>';
+	?>
+</article><!-- .post -->

--- a/wp-content/themes/csisnuclearnetwork/template-parts/entry-header-blue.php
+++ b/wp-content/themes/csisnuclearnetwork/template-parts/entry-header-blue.php
@@ -18,7 +18,9 @@ $is_search = is_search(); //Search
 $is_home = is_home(); //Analysis
 $page_for_posts = get_option( 'page_for_posts' );
 $is_tag = is_tag(); //Tag
-$is_series = is_tax('series'); //Series
+$series_page = get_field('series_page', 'option'); // Series page as archive
+$series_page_id = $series_page->ID;
+$is_series = is_tax('series') || is_page( $series_page_id ); //Series
 $is_analysis_subtype = is_tax('analysis_subtype');
 $is_event_subtype = is_tax('event_types');
 $is_category = is_category(); //Category
@@ -56,27 +58,37 @@ if ( $template === 'templates/template-no-image.php' ){
 
 <?php
 
-	if ( $is_series || $is_analysis_subtype ) { ?>
-
-			<?php 
-			the_archive_title( '<h1 class="' . $title_classes . '"> Analysis / <span class="entry-header__title-secondary">', '</span></h1>' ); ?>
+	if ( $is_series || $is_analysis_subtype ) {
+		if ( is_page( $series_page_id ) ) {
+			the_title( '<h1 class="' . $title_classes . '"> Analysis / <span class="entry-header__title-secondary">', '</span></h1>' );
+		} else {
+			the_archive_title( '<h1 class="' . $title_classes . '"> Analysis / <span class="entry-header__title-secondary">', '</span></h1>' );
+		}
+		?>
 
 			<div class="entry-header__grid">
 
-				<div class="entry-header__desc text--short"><?php echo term_description(); ?></div>
-				
+				<div class="entry-header__desc text--short">
+					<?php
+						if ( is_page( $series_page_id ) ) {
+							the_content();
+						} else {
+							echo term_description();
+						}
+					?>
+				</div>
+
 				<a href="/analysis" class="entry-header__cta cta btn btn--med">All Analysis <?php echo nuclearnetwork_get_svg( 'chevron-right' ); ?></a>
-				
+
 				<div class="entry-header__write-for-us desktop-only">
 					<?php dynamic_sidebar( 'write-for-us' ); ?>
 				</div>
 			</div>
 			<?php
 
-			
 	} elseif ( $is_event_subtype ) { ?>
 
-		<?php 
+		<?php
 		the_archive_title( '<h1 class="' . $title_classes . '"> Events / <span class="entry-header__title-secondary">', '</span></h1>' ); ?>
 
 		<div class="entry-header__grid">
@@ -84,17 +96,17 @@ if ( $template === 'templates/template-no-image.php' ){
 		</div>
 		<?php
 
-		
+
 } elseif ( $is_search ) {
-			
+
 		$archive_title = sprintf(
 			'%1$s %2$s',
 			'<span class="entry-header__title-label">' . __( 'Search results for', 'nuclearnetwork' ) . '</span>',
 			'&lsquo;' . get_search_query() . '&rsquo;'
 		); ?>
-				
+
 			<h1 class="<?php echo $title_classes; ?>"><?php echo wp_kses_post( $archive_title ); ?></h1>
-			
+
 			<?php
 
 	} elseif ( $post_type === 'updates' && $is_archive ) {
@@ -103,7 +115,7 @@ if ( $template === 'templates/template-no-image.php' ){
 
 		<div class="entry-header__grid">
 			<div class="entry-header__desc text--short"><?php echo $description; ?></div>
-			
+
 			<div class="entry-header__newsletter desktop-only">
 				<h2>Monthly Newsletter</h2>
 				<p>Get PONI Program Updates delivered directly to your inbox by signing up for our monthly newsletter!</p>
@@ -136,7 +148,7 @@ if ( $template === 'templates/template-no-image.php' ){
 	} elseif ( $is_home ) {
 
 		$description = get_field( 'archive_description', $page_for_posts );
-		
+
 		$post = get_page($page_for_posts);
 		setup_postdata($post); ?>
 		<h1 class="<?php echo $title_classes; ?>"><?php echo wp_kses_post( the_title() ); ?></h1>
@@ -153,14 +165,14 @@ if ( $template === 'templates/template-no-image.php' ){
 	} elseif ( $is_archive ) {
 
 		the_archive_title( '<h1 class="' . $title_classes . '">', '</h1>' ); ?>
-		
+
 		<div class="entry-header__desc text--short"><?php echo $description; ?></div>
 		<?php
 
 	} elseif ( $is_category || $is_tag ) {
 
 		the_archive_title( '<h1 class="' . $title_classes . '">', '</h1>' ); ?>
-		
+
 		<div class="entry-header__desc text--short"><?php echo $description; ?></div>
 		<?php
 


### PR DESCRIPTION
This adds a special page layout for the Series page. WordPress doesn't automatically create pages where the terms of a taxonomy are listed, so we have to create a "Page" and give it a special layout. This makes modifications to other elements of the archive template parts so this page mimics the look and function of an archive.

You must pull down from Development to get changes to the ACF fields and the new page to see this change.