### PR TITLE
Bugs from ilab testing

### DIFF
--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/abstracts/_placeholders.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/abstracts/_placeholders.scss
@@ -96,6 +96,11 @@
   letter-spacing: 0.01em;
 }
 
+%text-style-label-medium-strong {
+  @extend %text-style-label-medium;
+  font-weight: 700;
+}
+
 %text-style-label-small {
   @include font-size(14px);
   font-family: $font__pt;

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_entry-header.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_entry-header.scss
@@ -178,8 +178,8 @@
     .featured-media {
       width: 100%;
 
-      @include breakpoint('large') {
-        img {
+      img {
+        @include breakpoint('large') {
           margin-right: auto;
           margin-left: auto;
         }
@@ -192,7 +192,6 @@
         height: fit-content;
         margin-right: auto;
         margin-left: auto;
-
         /* stylelint-disable */
         &::after {
           @include z-index('entryHeaderImgFlair');
@@ -205,6 +204,15 @@
           background-color: $color-accent-secondary-yellow-100;
         }
         /* stylelint-enable */
+      }
+
+      &__caption {
+        @extend %text-style-paragraph-medium-short;
+        max-width: $size__content-max-width;
+        margin-top: calc(rem(12) + rem(8)); //The margin from the mockup plus the height of the pseudo element
+        margin-right: auto;
+        margin-left: auto;
+        color: $color-black-165;
       }
     }
 

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_entry-header.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_entry-header.scss
@@ -399,8 +399,14 @@
 
     .write-for-us {
       --write-title-color: #{$color-accent-secondary-yellow-100};
+      --write-title-hover-color: #{$color-white-100};
+      --write-title-focus-color: #{$color-white-100};
+      --write-title-focus-bg-color: #{$color-accent-primary-blue-100};
       --write-body-color: #{$color-white-100};
       --write-link-color: #{$color-white-100};
+      --write-link-hover-color: #{$color-accent-secondary-yellow-100};
+      --write-link-focus-color: #{$color-white-100};
+      --write-link-focus-bg-color: #{$color-accent-primary-blue-100};
     }
   }
 

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_footnotes.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_footnotes.scss
@@ -44,6 +44,7 @@
     display: block;
     padding-left: rem(16) !important;
     color: $color-black-180;
+    overflow-wrap: break-word;
 
     &::after {
       position: absolute;

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_footnotes.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_footnotes.scss
@@ -40,7 +40,7 @@
 
   li {
     position: relative;
-    left: 8px;
+    left: 16px;
     display: block;
     padding-left: rem(16) !important;
     color: $color-black-180;
@@ -49,7 +49,7 @@
     &::after {
       position: absolute;
       top: 0;
-      left: -8px;
+      left: -16px;
       display: block;
       margin-left: 0;
       content: counter(item) '.';

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_home-about-poni.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_home-about-poni.scss
@@ -35,12 +35,14 @@
       a {
         text-decoration: underline;
 
+        /* stylelint-disable-next-line */
         &:hover,
         &:focus {
           color: $color-white-100;
           text-decoration: none;
         }
 
+        /* stylelint-disable-next-line */
         &:focus {
           background-color: $color-accent-primary-100;
           outline: 0;

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_home-about-poni.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_home-about-poni.scss
@@ -31,7 +31,21 @@
     &-description {
       @extend %text-style-paragraph-medium;
       padding-bottom: rem(24);
-      color: $color-white-190;
+
+      a {
+        text-decoration: underline;
+
+        &:hover,
+        &:focus {
+          color: $color-white-100;
+          text-decoration: none;
+        }
+
+        &:focus {
+          background-color: $color-accent-primary-100;
+          outline: 0;
+        }
+      }
     }
 
     &-people {
@@ -45,14 +59,14 @@
       // This is where you would style the individual items in the definition list
       display: grid;
       flex: 1 1 calc(50% - #{rem(24)});
-      grid-template-areas: 
+      grid-template-areas:
         'image name'
         'image title';
       grid-template-columns: 100px auto;
       grid-template-rows: max-content 1fr;
       column-gap: rem(16);
       row-gap: rem(2);
-      
+
       &-image {
         grid-area: image;
 
@@ -90,7 +104,7 @@
         width: 100%;
         max-width: rem(720);
       }
-      
+
       img {
         width: calc(100% + var(--container-padding));
         max-width: unset;

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_post-block-related.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_post-block-related.scss
@@ -29,7 +29,7 @@
   &__title {
     margin-bottom: rem(12);
     color: $color-black-100;
-    @extend %text-style-heading-medium;
+    @extend %text-style-heading-medium-strong;
 
     &:hover {
       color: $color-accent-primary-blue-200;

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_post-block.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_post-block.scss
@@ -110,8 +110,8 @@
     }
 
     /* stylelint-disable */
-    a[href*="//"]:not([class]):not([href*="nuclearnetwork.local"]):not([href*="localhost"]):not([href*="nuclearnetwork"]),
-    a[href*="//"]:not([href*="nuclearnetwork.local"]):not([href*="localhost"]):not([href*="nuclearnetwork"]).post-block__news-link h3
+    a[href*="//"]:not([class]):not([href*="nuclearnetwork.local"]):not([href*="localhost"]):not([href*="nuclearnetwork"]):not([href*="csisngnndev"]):not([href*="csisngnnstage"]),
+    a[href*="//"]:not([href*="nuclearnetwork.local"]):not([href*="localhost"]):not([href*="nuclearnetwork"]):not([href*="csisngnndev"]):not([href*="csisngnnstage"]).post-block__news-link h3
     {
       /* stylelint-enable */
       &::after {
@@ -150,7 +150,7 @@
       }
 
       /* stylelint-disable */
-      a[href*="//"]:not([class]):not([href*="nuclearnetwork.local"]):not([href*="localhost"]):not([href*="nuclearnetwork"])
+      a[href*="//"]:not([class]):not([href*="nuclearnetwork.local"]):not([href*="localhost"]):not([href*="nuclearnetwork"]):not([href*="csisngnndev"]):not([href*="csisngnnstage"])
       {
         /* stylelint-enable */
         &::after {

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_resources.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_resources.scss
@@ -19,4 +19,15 @@
       margin-bottom: rem(12);
     }
   }
+
+  hr {
+    height: 1px;
+    margin-bottom: rem(56);
+    background-color: $color-border-dark-130;
+    border: 0;
+
+    @include breakpoint('large') {
+      margin-bottom: rem(32);
+    }
+  }
 }

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_team-member-block.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_team-member-block.scss
@@ -7,6 +7,7 @@
 
   .team-member-block__ul li {
     padding-bottom: rem(20);
+    padding-left: 0;
 
     @include breakpoint('medium') {
       display: flex;

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_write-for-us.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/components/_write-for-us.scss
@@ -2,13 +2,37 @@
 
 .write-for-us {
   --write-title-color: #{$color-accent-primary-blue-200};
+  --write-title-hover-color: #{$color-accent-primary-blue-100};
+  --write-title-focus-color: #{$color-accent-primary-blue-100};
+  --write-title-focus-bg-color: #{$color-bg-light-300};
   --write-body-color: #{$color-accent-primary-blue-100};
   --write-link-color: #{$color-accent-primary-blue-200};
+  --write-link-hover-color: #{$color-accent-primary-blue-100};
+  --write-link-focus-color: #{$color-accent-primary-blue-100};
+  --write-link-focus-bg-color: #{$color-bg-light-300};
 
   &__title {
     @extend %text-style-label-large-strong-caps;
     margin-bottom: rem(4);
     color: var(--write-title-color);
+
+    a:hover {
+      color: var(--write-title-hover-color);
+
+      .icon {
+        color: var(--write-title-hover-color, inherit);
+      }
+    }
+
+    a:focus {
+      color: var(--write-title-focus-color, --link-color);
+      background-color: var(--write-title-focus-bg-color);
+      outline: 0;
+
+      .icon {
+        color: var(--write-title-focus-color, inherit);
+      }
+    }
   }
 
   &__desc,
@@ -21,6 +45,18 @@
   }
 
   &__link {
-    color: var(--write-link-color);
+    a {
+      color: var(--write-link-color);
+
+      &:hover {
+        color: var(--write-link-hover-color);
+      }
+
+      &:focus {
+        color: var(--write-link-focus-color, --link-color);
+        background-color: var(--write-link-focus-bg-color);
+        outline: 0;
+      }
+    }
   }
 }

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/home.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/home.scss
@@ -918,7 +918,6 @@
         text-align: left;
 
         &__title {
-          @extend %text-style-heading-medium-strong;
           color: $color-white-100;
 
           &:hover {

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/home.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/home.scss
@@ -842,6 +842,7 @@
         'news'
         'twitter';
       grid-template-columns: 1fr;
+      grid-template-rows: repeat(3, min-content);
       padding-top: rem(40);
     }
 

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/home.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/home.scss
@@ -918,7 +918,7 @@
         text-align: left;
 
         &__title {
-          @extend %text-style-heading-medium;
+          @extend %text-style-heading-medium-strong;
           color: $color-white-100;
 
           &:hover {

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/post.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/post.scss
@@ -3,12 +3,10 @@
 .post {
   &__authors {
     --max-width-limit: #{rem(500)};
-    --padding-top-authors: #{rem(56)};
     margin-top: rem(0);
     margin-bottom: rem(56);
 
     @include breakpoint('large') {
-      --padding-top-authors: #{rem(32)};
       margin-bottom: rem(48);
 
       &-content {
@@ -26,13 +24,6 @@
         max-width: unset;
         margin-bottom: rem(48);
       }
-    }
-
-    hr {
-      height: 1px;
-      margin-bottom: var(--padding-top-authors);
-      background-color: $color-border-dark-130;
-      border: 0;
     }
 
     &-heading {

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/post.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/post.scss
@@ -4,7 +4,7 @@
   &__authors {
     --max-width-limit: #{rem(500)};
     --padding-top-authors: #{rem(56)};
-    margin-top: rem(24);
+    margin-top: rem(0);
     margin-bottom: rem(56);
 
     @include breakpoint('large') {
@@ -40,13 +40,13 @@
       margin-bottom: rem(16);
 
       @include breakpoint('large') {
-        margin-bottom: rem(32);
+        margin-bottom: rem(12);
       }
     }
 
     &-disclaimer {
       max-width: var(--max-width-limit);
-      margin-bottom: rem(32);
+      margin-bottom: rem(24);
       color: $color-black-190;
       letter-spacing: 0.0005em;
 
@@ -56,7 +56,7 @@
     }
 
     &-author {
-      margin-bottom: rem(24);
+      margin-bottom: rem(16);
 
       &:last-of-type {
         margin: 0;

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/single.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/single.scss
@@ -393,20 +393,26 @@
 
   /* stylelint-disable-next-line */
   h2.cite__heading {
+    display: none;
     color: $color-accent-primary-blue-100;
     @extend %text-style-label-medium;
+
+    @include breakpoint('large') {
+      display: block;
+    }
   }
 
   .cite__container {
     @extend %text-style-paragraph-small;
+    display: none;
     grid-column: 1;
-    max-width: rem(500);
     color: $color-black-165;
 
     @include breakpoint('large') {
-      max-width: unset;
+      display: block;
     }
 
+    /* stylelint-disable-next-line */
     .btn svg {
       margin-right: rem(8);
       margin-left: 0;

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/single.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/single.scss
@@ -98,7 +98,7 @@
       @extend %text-style-long;
     }
 
-    ul:not(.career-block__li):not(.class-links-block__classes),
+    ul:not(.career-block__li):not(.class-links-block__classes):not(.team-member-block__ul),
     ol:not(.footnotes__list):not(.easy-footnotes-wrapper) {
       margin-top: rem(16px);
       padding-left: rem(42px);
@@ -107,7 +107,7 @@
       color: $color-gray-190;
     }
 
-    li:not(.career-block__li):not(.class-links-block__class) {
+    li:not(.career-block__li):not(.class-links-block__class):not(.team-member-block__ul li) {
       padding-left: rem(18px);
     }
 
@@ -115,7 +115,7 @@
       margin-top: rem(12px);
     }
 
-    ol:not(.footnotes__list):not(.easy-footnotes-wrapper),
+    ol:not(.footnotes__list):not(.easy-footnotes-wrapper) li::marker,
     li::marker {
       color: $color-accent-secondary-yellow-100;
     }
@@ -303,7 +303,6 @@
       color: $color-accent-primary-blue-100;
       @include font-size(28px);
       font-family: $font__lato;
-      letter-spacing: 0.05em;
     }
 
     &-related-container {
@@ -333,12 +332,17 @@
       padding: 0;
 
       @include breakpoint('large') {
+        margin-top: 0;
         margin-bottom: 0;
       }
 
       li:first-child {
         margin-bottom: rem(32);
       }
+    }
+
+    .post-block-related__title {
+      margin-bottom: rem(8);
     }
 
     &-label {

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/single.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/single.scss
@@ -142,7 +142,7 @@
     }
 
     /* stylelint-disable */
-    a[href*="//"]:not([class]):not([href*="nuclearnetwork.local"]):not([href*="localhost"]):not([href*="nuclearnetwork"])
+    a[href*="//"]:not([class]):not([href*="nuclearnetwork.local"]):not([href*="localhost"]):not([href*="nuclearnetwork"]):not([href*="csisngnndev"]):not([href*="csisngnnstage"])
     {
       /* stylelint-enable */
       &::after {

--- a/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/single.scss
+++ b/wp-content/themes/csisnuclearnetwork/assets/_scss/pages/single.scss
@@ -406,6 +406,11 @@
     @include breakpoint('large') {
       max-width: unset;
     }
+
+    .btn svg {
+      margin-right: rem(8);
+      margin-left: 0;
+    }
   }
 
   .cite__citation {

--- a/wp-content/themes/csisnuclearnetwork/inc/template-tags.php
+++ b/wp-content/themes/csisnuclearnetwork/inc/template-tags.php
@@ -471,7 +471,7 @@ if ( ! function_exists( 'nuclearnetwork_citation' ) ) :
 			$title = get_the_archive_title();
 		}
 
-		printf( '<h2 class="cite__heading text--bold text--caps">Cite this Page</h2><p class="cite__container text--short"><span class="cite__citation">' . esc_html( '%1$s, "%2$s,"', 'nuclearnetwork' ) . ' <em>%3$s</em>' . esc_html( ', Center for Strategic and International Studies, %4$s, %5$s%6$s.', 'nuclearnetwork') . '</span><button id="btn-copy" class="btn btn--outline-dark btn--icon btn--med" data-clipboard-target=".cite__citation" aria-label="Copied!">' . nuclearnetwork_get_svg( 'copy' ) . 'Copy Citation</button></p>', $authors, $title, get_bloginfo( 'name' ), get_the_date(), $modified_date, get_the_permalink() ); // WPCS: XSS OK.
+		printf( '<h2 class="cite__heading text--bold text--caps">Cite this Page</h2><p class="cite__container text--short"><span class="cite__citation">' . esc_html( '%1$s, "%2$s,"', 'nuclearnetwork' ) . ' <em>%3$s</em>' . esc_html( ', Center for Strategic and International Studies, %4$s, %5$s%6$s.', 'nuclearnetwork') . '</span><button id="btn-copy" class="btn btn--outline-dark btn--med" data-clipboard-target=".cite__citation" aria-label="Copied!">' . nuclearnetwork_get_svg( 'copy' ) . 'Copy Citation</button></p>', $authors, $title, get_bloginfo( 'name' ), get_the_date(), $modified_date, get_the_permalink() ); // WPCS: XSS OK.
 	}
 endif;
 

--- a/wp-content/themes/csisnuclearnetwork/template-parts/block-post-related.php
+++ b/wp-content/themes/csisnuclearnetwork/template-parts/block-post-related.php
@@ -15,7 +15,7 @@
 <article <?php post_class('post-block-related'); ?> id="post-<?php the_ID(); ?>">	
 	<?php nuclearnetwork_display_subtypes(); ?>
 	<?php
-		the_title( '<h3 class="post-block-related__title text--bold"><a class="post-block-related__title" href="' . esc_url( get_permalink() ) . '">', '</a></h3>' );
+		the_title( '<h3 class="post-block-related__title"><a class="post-block-related__title" href="' . esc_url( get_permalink() ) . '">', '</a></h3>' );
 	?>
 	<div class='post-block-related__byline'>
 		<?php nuclearnetwork_posted_on('M j, Y') ?> 

--- a/wp-content/themes/csisnuclearnetwork/template-parts/content.php
+++ b/wp-content/themes/csisnuclearnetwork/template-parts/content.php
@@ -34,7 +34,7 @@ get_template_part( 'template-parts/entry-header' );
 		<?php
 
 			get_template_part( 'template-parts/post-resources' );
-		  echo '<div class="post__authors"><hr>';
+		  echo '<div class="post__authors">';
 			echo '<h2 class="section__heading post__authors-heading single__section-heading">Authors</h2><p class="text--italic text--short post__authors-disclaimer">The views expressed above are the author’s and do not necessarily reflect those of the Center for Strategic and International Studies or the Project on Nuclear Issues.</p><div class="post__authors-content"><div class="post__authors-group">';
 			nuclearnetwork_authors_list_extended(); 
 			echo '</div><div class="single__footer-write-for-us">';

--- a/wp-content/themes/csisnuclearnetwork/template-parts/featured-image.php
+++ b/wp-content/themes/csisnuclearnetwork/template-parts/featured-image.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Displays the featured image
+ * Displays the featured image on light entry headers
  *
  * @package CSIS iLab
  * @subpackage @package NuclearNetwork
@@ -10,7 +10,9 @@
 $is_singular = is_singular();
 $is_front_page = is_front_page();
 
-if ( has_post_thumbnail() && ! post_password_required() ) {
+if ( has_post_thumbnail() && ! post_password_required() && !is_page_template( 'templates/template-no-image.php' ) ) {
+
+	$caption = get_the_post_thumbnail_caption();
 
 	?>
 
@@ -29,6 +31,12 @@ if ( has_post_thumbnail() && ! post_password_required() ) {
 			}
 		?>
 		</div>
+		<?php
+
+			if ( $caption ) {
+				echo '<div class="featured-media__caption">' . esc_html( $caption ) . '</div>';
+			}
+		?>
 	</figure><!-- .featured-media -->
 
 	<?php

--- a/wp-content/themes/csisnuclearnetwork/template-parts/home-about-poni.php
+++ b/wp-content/themes/csisnuclearnetwork/template-parts/home-about-poni.php
@@ -20,7 +20,7 @@
 		<?php 
 			$ngnn_site_description = get_field('ngnn_site_description');
 		?>
-		<p class="home__about-description text--short"><?php echo esc_html( $ngnn_site_description ) ?></p>
+		<div class="home__about-description text--short"><?php echo $ngnn_site_description ?></div>
 		<?php
 			$director_and_deputy_director = get_field( 'director_and_deputy_director' );
 			if ( $director_and_deputy_director ) :

--- a/wp-content/themes/csisnuclearnetwork/template-parts/newsletter-block-acf.php
+++ b/wp-content/themes/csisnuclearnetwork/template-parts/newsletter-block-acf.php
@@ -43,14 +43,13 @@
 
     $dailyNewsletterName = get_field('daily_newsletter_name');
     $dailyNewsletterDesc = get_field('daily_newsletter_description');
-    $dailyNewsletterLinks = "<div class='recent-news'><a class='home__archive-link text--link' href=" . $recentNewsUrl . ">Most recent newsletter" .nuclearnetwork_get_svg('chevron-right') . "</a><a class='home__archive-link text--link' href=" . get_post_type_archive_link( 'news' ) . ">All Nuclear Policy News" .nuclearnetwork_get_svg('chevron-right') . "</a></div>";
+    $dailyNewsletterLinks = "<div class='recent-news'><a class='home__archive-link text--link' href=" . $recentNewsUrl . ">Most recent news" .nuclearnetwork_get_svg('chevron-right') . "</a><a class='home__archive-link text--link' href=" . get_post_type_archive_link( 'news' ) . ">All Nuclear Policy News" .nuclearnetwork_get_svg('chevron-right') . "</a></div>";
     $monthlyNewsletterName = get_field('monthly_newsletter_name');
     $monthlyNewsletterDesc = get_field('monthly_newsletter_description');
-    $monthlyNewsletterLinks = "<div class='recent-news'><a class='home__archive-link text--link' href=" . $recentUpdatesUrl . ">Most recent newsletter" .nuclearnetwork_get_svg('chevron-right') . "</a></div>";
 
     $constructedDailyNewsletter = "<div class='daily'><h3>" . $dailyNewsletterName . "</h3><p class='text--short'>" . $dailyNewsletterDesc . "</p><a class='subscribe btn btn--teal btn--newsletter' href=" . get_field('nuclear_policy_news_link', 'option') . ">Subscribe</a>" . $dailyNewsletterLinks . "</div>";
 
-    $constructedMonthlyNewsletter = "<div class='monthly'><h3>" . $monthlyNewsletterName . "</h3><p class='text--short'>" . $monthlyNewsletterDesc . "</p><a class='subscribe btn btn--teal btn--newsletter' href=" . get_field('monthly_newsletter_link', 'option') . ">Subscribe</a>" . $monthlyNewsletterLinks . "</div>";
+    $constructedMonthlyNewsletter = "<div class='monthly'><h3>" . $monthlyNewsletterName . "</h3><p class='text--short'>" . $monthlyNewsletterDesc . "</p><a class='subscribe btn btn--teal btn--newsletter' href=" . get_field('monthly_newsletter_link', 'option') . ">Subscribe</a></div>";
 
     $output = "<div class='newsletter-block-acf'><h2 class='home__subtitle'>Newsletters</h3>" . $constructedDailyNewsletter . $constructedMonthlyNewsletter . "</div>";
 

--- a/wp-content/themes/csisnuclearnetwork/template-parts/post-resources.php
+++ b/wp-content/themes/csisnuclearnetwork/template-parts/post-resources.php
@@ -16,6 +16,6 @@ $resources = get_field( 'resources' );
 
 if ( ! empty( $resources ) ) {
   echo '<div class="resources"><h2 class="resources__heading single__section-heading">Resources</h2>
-  <div class="resources__content">' . $resources . '</div></div>';
+  <div class="resources__content">' . $resources . '</div></div><hr>';
 }
 ?>


### PR DESCRIPTION
This post fixes the following.

- Related posts on the homepage and single posts don't have a bold title.  The placeholder typography was overriding the `text--bold` class, so I made a new placeholder for heading medium strong.
- The twitter section on the homepage had a large gap above it on desktop, so I adjusted the grid template rows.
- Per request from Joseph, I changed the name of the CTA for most recent NPN to "Most recent news" and removed the link to the most recent monthly newsletter. 
- The Write For Us block in post footers and the analysis archive header have focus and hover styles.
- The Write For Us block title is a link now.
- Added link styles for About PONI section of homepage.